### PR TITLE
fix case where the tokenStorage would not check if there was an exist…

### DIFF
--- a/src/TokenStorage.js
+++ b/src/TokenStorage.js
@@ -17,18 +17,23 @@ class TokenStorage {
   }
 
   getAccessToken() {
-    if (! this._hasATokenBeenGenerated && !this._tokenGenerator.canAutogenerateToken) {
-      throw new Error('No token has been generated yet.');
-    }
-    if (! this._hasATokenBeenGenerated && this._tokenGenerator.canAutogenerateToken) {
-      return this._tokenGenerator.generateToken()
-        .then(() => this._asyncStorage.getItem(ACCESS_TOKEN_KEY))
-        .then(token => token && JSON.parse(token).access_token)
-      ;
-    }
-
     return this._asyncStorage.getItem(ACCESS_TOKEN_KEY)
-      .then(token => token && JSON.parse(token).access_token)
+      .then(token => {
+        if (!token) {
+          if (!this._hasATokenBeenGenerated && !this._tokenGenerator.canAutogenerateToken) {
+            throw new Error('No token has been generated yet.');
+          }
+
+          if (!this._hasATokenBeenGenerated && this._tokenGenerator.canAutogenerateToken) {
+            return this._tokenGenerator.generateToken()
+              .then(() => this._asyncStorage.getItem(ACCESS_TOKEN_KEY))
+              .then(generatedToken => generatedToken && JSON.parse(generatedToken).access_token)
+            ;
+          }
+        }
+
+        return token && JSON.parse(token).access_token;
+      })
     ;
   }
 

--- a/test/TokenStorage_specs.js
+++ b/test/TokenStorage_specs.js
@@ -14,20 +14,27 @@ import Storage from './mock/mockStorage';
 const tokenGeneratorMock = new TokenGeneratorMock();
 
 describe('Token storage tests', () => {
-  it('handle empty token', () => {
+  it('handle empty token', (done) => {
     const oauth = new TokenStorage(tokenGeneratorMock, new Storage());
 
     const hasAccessToken = oauth.hasAccessToken();
     expect(hasAccessToken).to.be.an.instanceOf(Promise);
 
-    expect(() => oauth.getAccessToken()).to.throw(Error, /No token has been generated yet/);
-    oauth.generateToken();
-    const accessToken = oauth.getAccessToken();
+    oauth.getAccessToken()
+    .catch(e => {
+      expect(e.message).to.equal('No token has been generated yet.');
+    })
+    .then(() => {
+      oauth.generateToken();
+      const accessToken = oauth.getAccessToken();
 
-    return Promise.all([
-      expect(hasAccessToken).to.eventually.be.false,
-      expect(accessToken).to.eventually.be.undefined,
-    ]);
+      Promise.all([
+        expect(hasAccessToken).to.eventually.be.false,
+        expect(accessToken).to.eventually.be.undefined,
+      ])
+      .then(() => done());
+    })
+    ;
   });
 
   it('handle non empty token', () => {
@@ -41,7 +48,6 @@ describe('Token storage tests', () => {
     const hasAccessToken = oauth.hasAccessToken();
     expect(hasAccessToken).to.be.an.instanceOf(Promise);
 
-    expect(() => oauth.getAccessToken()).to.throw(Error, /No token has been generated yet/);
     oauth.generateToken();
     const accessToken = oauth.getAccessToken();
 


### PR DESCRIPTION
Current problem:

If there is a token in the storage, the TokenStorage would not even check the asyncStorage, and just throw an error, because it expects to have generated the token in the current instance.
(which is not quite the case when using localStorage/indexedDb, etc...)