### PR TITLE
memoize togen generation and refresh

### DIFF
--- a/src/TokenGenerator/ClientCredentialsGenerator.js
+++ b/src/TokenGenerator/ClientCredentialsGenerator.js
@@ -1,11 +1,17 @@
 import URI from 'urijs';
 import AbstractTokenGenerator from './AbstractTokenGenerator';
+import { memoizePromise } from '../decorator';
 
 const ERROR_CONFIG_EMPTY = 'TokenGenerator config must be set';
 const ERROR_CONFIG_PATH_SCHEME = 'TokenGenerator config is not valid, it should contain a "path", a "scheme" parameter';
 const ERROR_CONFIG_CLIENT_INFORMATIONS = 'TokenGenerator config is not valid, it should contain a "clientId", a "clientSecret" parameter';
 
 class ClientCredentialsGenerator extends AbstractTokenGenerator {
+  constructor(props) {
+    super(props);
+    this.generateToken = memoizePromise(this.generateToken);
+  }
+
   generateToken(baseParameters = {}) {
     const parameters = baseParameters;
     parameters.grant_type = 'client_credentials';

--- a/src/TokenGenerator/PasswordGenerator.js
+++ b/src/TokenGenerator/PasswordGenerator.js
@@ -1,5 +1,6 @@
 import URI from 'urijs';
 import AbstractTokenGenerator from './AbstractTokenGenerator';
+import { memoizePromise } from '../decorator';
 
 const ERROR_CONFIG_EMPTY = 'TokenGenerator config must be set';
 const ERROR_CONFIG_PATH_SCHEME = 'TokenGenerator config is not valid, it should contain a "path", a "scheme" parameter';
@@ -10,6 +11,11 @@ const ERROR_TOKEN_USERNAME_PASSWORD = 'username and password must be passed as p
 const ERROR_TOKEN_ACCESS_TOKEN_REFRESH_TOKEN = 'access_token and refresh_token be passed as parameters';
 
 class PasswordGenerator extends AbstractTokenGenerator {
+  constructor(props) {
+    super(props);
+    this._doFetch = memoizePromise(this._doFetch);
+  }
+
   generateToken(baseParameters) {
     const parameters = baseParameters;
     this._checkGenerateParameters(parameters);

--- a/src/decorator.js
+++ b/src/decorator.js
@@ -1,0 +1,32 @@
+// memoize promise returning function so that it returns
+// the same promise if called again before resolve / reject
+export function memoizePromise(callback) {
+  const cache = {};
+  function memoized(...parameters) {
+    const cacheKey = JSON.stringify(parameters);
+
+    if (cache[cacheKey]) {
+      return cache[cacheKey];
+    }
+
+    // Get and add the value to the cache
+    const value = callback.apply(this, parameters);
+    cache[cacheKey] = value;
+
+    if (!value || value.constructor.name !== 'Promise') {
+      throw new Error('Memoization Error, Async function returned non-promise value');
+    }
+
+    // Delete the value regardless of whether it resolves or rejects
+    return value.then(internalValue => {
+      cache[cacheKey] = false;
+      return internalValue;
+    }, err => {
+      cache[cacheKey] = false;
+      throw err;
+    });
+  }
+
+  memoized.cache = cache;
+  return memoized;
+}

--- a/src/decorator.js
+++ b/src/decorator.js
@@ -13,7 +13,7 @@ export function memoizePromise(callback) {
     const value = callback.apply(this, parameters);
     cache[cacheKey] = value;
 
-    if (!value || value.constructor.name !== 'Promise') {
+    if (!value || !(value instanceof Promise)) {
       throw new Error('Memoization Error, Async function returned non-promise value');
     }
 

--- a/test/MemoizePromise_specs.js
+++ b/test/MemoizePromise_specs.js
@@ -1,0 +1,62 @@
+/* global describe, it, afterEach */
+import { expect } from 'chai';
+import { memoizePromise } from '../src/decorator';
+
+let count;
+function someFunctionReturningAPromise(params) {
+  return new Promise(resolve => {
+    count++;
+    return resolve(count);
+  });
+}
+
+describe('Test 2 simultaneous calls return promises', () => {
+  it('2 simultaneous calls with same params return different promise results', () => {
+    count = 0;
+    const promise1 = someFunctionReturningAPromise({ foo: 'bar' });
+    const promise2 = someFunctionReturningAPromise({ foo: 'bar' });
+
+    expect(promise1).to.be.an.instanceOf(Promise);
+    expect(promise2).to.be.an.instanceOf(Promise);
+
+    return Promise.all([
+      expect(promise1).to.eventually.be.equals(1),
+      expect(promise2).to.eventually.be.equals(2),
+    ]);
+  });
+
+  it('2 simultaneous decorated calls with different params return different promise results', () => {
+    const decoratedFunction = memoizePromise(someFunctionReturningAPromise);
+
+    count = 0;
+    const promise1 = decoratedFunction({ foo: 'bar' });
+    const promise2 = decoratedFunction({ bar: 'foo' });
+
+    expect(promise1).to.be.an.instanceOf(Promise);
+    expect(promise2).to.be.an.instanceOf(Promise);
+
+    expect(promise1).to.not.equals(promise2);
+
+    return Promise.all([
+      expect(promise1).to.eventually.be.equals(1),
+      expect(promise2).to.eventually.be.equals(2),
+    ]);
+  });
+
+  it('2 simultaneous decorated calls with same params return same promise result', () => {
+    const decoratedFunction = memoizePromise(someFunctionReturningAPromise);
+
+    count = 0;
+    const promise1 = decoratedFunction({ foo: 'bar' });
+    const promise2 = decoratedFunction({ foo: 'bar' });
+
+    expect(promise1).to.be.an.instanceOf(Promise);
+    expect(promise2).to.be.an.instanceOf(Promise);
+
+    return Promise.all([
+      expect(promise1).to.eventually.be.equals(1),
+      expect(promise2).to.eventually.be.equals(1),
+    ]);
+  });
+});
+


### PR DESCRIPTION
In order to avoid double call to generate or refresh token when sending simultaneous requests