### PR TITLE
remove param map in providedToken, provide an async function to fully control the behavior

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,12 @@
+# v0.10.x
+## breaking changes
+
+- `ProviderTokenGenerator` does not accept a param object anymore on its second argument.
+
+## new features
+
+- `ProviderTokenGenerator` now accept a function on its second argument which will be called on `refreshToken`, so you can fully customize the behavior. The function must return a Promise.
+
 # v0.9.x
 ## breaking changes
 

--- a/src/TokenGenerator/ProvidedTokenGenerator.js
+++ b/src/TokenGenerator/ProvidedTokenGenerator.js
@@ -1,14 +1,13 @@
 /* global fetch */
-import URI from 'urijs';
 import AbstractTokenGenerator from './AbstractTokenGenerator';
 
 class ProvidedTokenGenerator extends AbstractTokenGenerator {
 
-  constructor(token, params = {}) {
+  constructor(token, refreshTokenFunc = null) {
     super();
     this._token = token;
     this.canAutogenerateToken = true;
-    this._params = params;
+    this._refreshTokenFunc = refreshTokenFunc;
   }
 
   generateToken() {
@@ -18,23 +17,8 @@ class ProvidedTokenGenerator extends AbstractTokenGenerator {
   }
 
   refreshToken() {
-    if (this._params && this._params.refreshTokenUrl) {
-      const uri = new URI(this._params.refreshTokenUrl);
-
-      const url = uri.toString();
-
-      return fetch(url, {
-        method: 'POST',
-      })
-        .then((response) => {
-          if (response.status !== 200) {
-            return response.json()
-              .then(responseData => Promise.reject(responseData));
-          }
-
-          return response.json();
-        })
-      ;
+    if (typeof this._refreshTokenFunc === 'function') {
+      return this._refreshTokenFunc();
     }
 
     return this.generateToken();

--- a/test/TokenGenerator/ProvidedTokenGenerator_specs.js
+++ b/test/TokenGenerator/ProvidedTokenGenerator_specs.js
@@ -1,4 +1,4 @@
-/* global describe, it, afterEach */
+/* global fetch, describe, it, afterEach */
 global.FormData = require('form-data');
 import {
   expect,
@@ -70,18 +70,29 @@ describe('ProvidedTokenGenerator tests', () => {
     ;
   });
 
-  it('refresh the token if a refreshTokenUrl is set', () => {
+  it('refresh the token if the second parameter is set', () => {
     const newToken = { a: 'new token' };
     fetchMock
       .mock('^http://foo.bar', newToken)
       .getMock()
     ;
 
+    const refreshFunc = () => (
+      fetch('http://foo.bar', {
+        method: 'POST',
+      })
+        .then((response) => {
+          if (response.status !== 200) {
+            return response.json()
+              .then(responseData => Promise.reject(responseData));
+          }
+
+          return response.json();
+        })
+    );
+
     const tokenGenerator = new ProvidedTokenGenerator(
-      providedToken,
-      {
-        refreshTokenUrl: 'http://foo.bar/',
-      }
+      providedToken, refreshFunc,
     );
 
     return expect(tokenGenerator.refreshToken()).to.eventually.deep.equals(newToken)


### PR DESCRIPTION
It allows us to fully control what to do when we need to refresh a ProvidedToken