### PR TITLE
fix test to determine if a value is a promise

### DIFF
--- a/src/decorator.js
+++ b/src/decorator.js
@@ -13,15 +13,16 @@ export function memoizePromise(callback) {
     const value = callback.apply(this, parameters);
     cache[cacheKey] = value;
 
-    if (!value || !(value instanceof Promise)) {
+    const isPromise = !!value && typeof value.then === 'function';
+    if (!isPromise) {
       throw new Error('Memoization Error, Async function returned non-promise value');
     }
 
     // Delete the value regardless of whether it resolves or rejects
-    return value.then(internalValue => {
+    return value.then((internalValue) => {
       cache[cacheKey] = false;
       return internalValue;
-    }, err => {
+    }, (err) => {
       cache[cacheKey] = false;
       throw err;
     });


### PR DESCRIPTION
The current implementation would fail if the environment does not have native Promises.
Here are a few examples to determine if a variable is a promise: http://stackoverflow.com/questions/27746304/how-do-i-tell-if-an-object-is-a-promise/38339199#38339199

I only used the simplest method though