### PR TITLE
Fix refreshToken method not actually refreshing the token

### DIFF
--- a/src/client/AbstractClient.js
+++ b/src/client/AbstractClient.js
@@ -194,7 +194,7 @@ class AbstractClient {
         params.headers = {};
       }
 
-      params.headers = Object.assign(baseHeaders, params.headers);
+      params.headers = Object.assign(params.headers, baseHeaders);
     } else {
       params = { headers: baseHeaders };
     }

--- a/src/client/AbstractClient.js
+++ b/src/client/AbstractClient.js
@@ -197,11 +197,12 @@ class AbstractClient {
         params.headers = {};
       }
 
-      params.headers = Object.assign(baseHeaders, params.headers, authHeader);
+      params.headers = Object.assign(baseHeaders, params.headers);
     } else {
       params = { headers: baseHeaders };
     }
 
+    params.headers = Object.assign(params.headers, authHeader);
     params.headers = this._removeUndefinedHeaders(params.headers);
 
     return fetch(input, params)

--- a/src/client/AbstractClient.js
+++ b/src/client/AbstractClient.js
@@ -180,8 +180,11 @@ class AbstractClient {
     let params = init;
 
     const baseHeaders = {
-      Authorization: `${this.sdk.config.authorizationType} ${accessToken}`,
       'Content-Type': 'application/json',
+    };
+
+    const authHeader = {
+      Authorization: `${this.sdk.config.authorizationType} ${accessToken}`,
     };
 
     const currentUri = typeof window === 'object' && window.location && window.location.href;
@@ -194,7 +197,7 @@ class AbstractClient {
         params.headers = {};
       }
 
-      params.headers = Object.assign(params.headers, baseHeaders);
+      params.headers = Object.assign(baseHeaders, params.headers, authHeader);
     } else {
       params = { headers: baseHeaders };
     }

--- a/test/client/AbstractClient_specs.js
+++ b/test/client/AbstractClient_specs.js
@@ -253,12 +253,49 @@ describe('Test Client', () => {
     return Promise.all([
       SomeSdk.test.find(8),
       BasicAuthSdk.test.find(8),
-    ])
-    .then(() => {
+    ]).then(() => {
       const authHeader = fetchMock.calls().matched[0][1].headers.Authorization;
       expect(authHeader).to.include('Bearer ');
-      const basicAuthHeader = fetchMock.calls().matched[1][1].headers.Authorization;
+      const basicAuthHeader = fetchMock.calls().matched[1][1].headers
+        .Authorization;
       expect(basicAuthHeader).to.include('Basic ');
+    });
+  });
+
+  it('handle refreshing the authorization header', () => {
+    let send401 = true;
+    fetchMock
+      .mock('https://api.me/v2/test/8', 'GET', function() {
+        if (send401) {
+          send401 = false;
+          return {
+            status: 401,
+            body: {
+              error: 'invalid_grant',
+              error_description: 'The access token provided has expired.',
+            },
+          };
+        } else {
+          return {
+            '@id': '/v1/test/8',
+          };
+        }
+      })
+      .getMock();
+
+    const BasicAuthSdk = new RestClientSdk(
+      tokenStorageMock,
+      { path: 'api.me', scheme: 'https', authorizationType: 'Basic' },
+      {
+        test: SomeTestClient,
+        defParam: DefaultParametersTestClient,
+      }
+    );
+
+    BasicAuthSdk.tokenStorage.generateToken();
+    return BasicAuthSdk.test.find(8).then(() => {
+      const authHeader = fetchMock.calls().matched[1][1].headers.Authorization;
+      expect(authHeader).to.equals('Basic refreshed-access-token');
     });
   });
 });
@@ -370,7 +407,6 @@ describe('Fix bugs', () => {
     return SomeSdk.test
       .authorizedFetch('foo', {
         headers: {
-          Authorization: undefined,
           'Content-Type': undefined,
           foo: undefined,
           bar: null,

--- a/test/client/AbstractClient_specs.js
+++ b/test/client/AbstractClient_specs.js
@@ -370,6 +370,7 @@ describe('Fix bugs', () => {
     return SomeSdk.test
       .authorizedFetch('foo', {
         headers: {
+          Authorization: undefined,
           'Content-Type': undefined,
           foo: undefined,
           bar: null,


### PR DESCRIPTION
The Authorization header was not updated, which means the SDK was trying in a loop to refresh the token + retry the query if a query has a 401 response.

Also added a test to make sure refreshToken works.