### PR TITLE
better dependencies management

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "deep-diff": "^0.3.8",
-    "immutable": "^4.0.0-rc.9",
     "urijs": "^1.19.0"
   },
   "devDependencies": {
@@ -35,6 +34,7 @@
     "fetch-mock": "^5.13.1",
     "form-data": "^2.1.2",
     "husky": "^0.14.3",
+    "immutable": "^4.0.0-rc.9",
     "jest": "^22.1.1",
     "lint-staged": "^6.0.0",
     "pluralize": "^7.0.0",
@@ -65,7 +65,7 @@
   "bundlesize": [
     {
       "path": "./dist/index.es.js",
-      "maxSize": "31 Kb"
+      "maxSize": "11 Kb"
     }
   ],
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "name": "rest-client-sdk",
-  "version": "2.0.0",
+  "version": "v2.0.1-rc.1",
   "description": "Rest Client SDK for API",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
-  "files": ["dist", "src"],
+  "files": [
+    "dist",
+    "src"
+  ],
   "scripts": {
     "clean": "rimraf dist",
     "test": "jest",
@@ -52,7 +55,11 @@
     "type": "git",
     "url": "git+https://github.com/mapado/rest-client-js-sdk.git"
   },
-  "keywords": ["Rest", "SDK", "API"],
+  "keywords": [
+    "Rest",
+    "SDK",
+    "API"
+  ],
   "author": "Mapado",
   "license": "MIT",
   "bugs": {
@@ -69,9 +76,14 @@
     }
   ],
   "lint-staged": {
-    "*.{js,jsx,json,md}": ["prettier --write", "git add"]
+    "*.{js,jsx,json,md}": [
+      "prettier --write",
+      "git add"
+    ]
   },
   "jest": {
-    "setupFiles": ["./setupJest.js"]
+    "setupFiles": [
+      "./setupJest.js"
+    ]
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,6 +6,7 @@ const pkg = require('./package.json');
 
 export default {
   input: 'src/index.js',
+  external: Object.keys(pkg.dependencies),
   plugins: [
     commonjs(),
     resolve(),
@@ -30,6 +31,10 @@ export default {
       name: 'rest-client-sdk',
       exports: 'named',
       sourcemap: true,
+      globals: {
+        'deep-diff': 'diff',
+        urijs: 'URI',
+      },
     },
     { file: pkg.module, format: 'es', sourcemap: true },
   ],

--- a/src/UnitOfWork.js
+++ b/src/UnitOfWork.js
@@ -1,5 +1,5 @@
-import { isImmutable } from 'immutable';
 import diff from 'deep-diff';
+import { isImmutable } from './isImmutable';
 
 /**
  * deep comparaison between objects

--- a/src/isImmutable.js
+++ b/src/isImmutable.js
@@ -1,0 +1,51 @@
+// "fork" of https://github.com/facebook/immutable-js/blob/v4.0.0-rc.9/src/Predicates.js
+// because tree-shaking does not seems to work as expected
+
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export function isImmutable(maybeImmutable) {
+  return isCollection(maybeImmutable) || isRecord(maybeImmutable);
+}
+
+export function isCollection(maybeCollection) {
+  return !!(maybeCollection && maybeCollection[IS_ITERABLE_SENTINEL]);
+}
+
+export function isKeyed(maybeKeyed) {
+  return !!(maybeKeyed && maybeKeyed[IS_KEYED_SENTINEL]);
+}
+
+export function isIndexed(maybeIndexed) {
+  return !!(maybeIndexed && maybeIndexed[IS_INDEXED_SENTINEL]);
+}
+
+export function isAssociative(maybeAssociative) {
+  return isKeyed(maybeAssociative) || isIndexed(maybeAssociative);
+}
+
+export function isOrdered(maybeOrdered) {
+  return !!(maybeOrdered && maybeOrdered[IS_ORDERED_SENTINEL]);
+}
+
+export function isRecord(maybeRecord) {
+  return !!(maybeRecord && maybeRecord[IS_RECORD_SENTINEL]);
+}
+
+export function isValueObject(maybeValue) {
+  return !!(
+    maybeValue &&
+    typeof maybeValue.equals === 'function' &&
+    typeof maybeValue.hashCode === 'function'
+  );
+}
+
+export const IS_ITERABLE_SENTINEL = '@@__IMMUTABLE_ITERABLE__@@';
+export const IS_KEYED_SENTINEL = '@@__IMMUTABLE_KEYED__@@';
+export const IS_INDEXED_SENTINEL = '@@__IMMUTABLE_INDEXED__@@';
+export const IS_ORDERED_SENTINEL = '@@__IMMUTABLE_ORDERED__@@';
+export const IS_RECORD_SENTINEL = '@@__IMMUTABLE_RECORD__@@';


### PR DESCRIPTION
300ko - > 55ko

Urijs and deep diff are "deported" to the caller package (it's not magic but Urijs is a package often used and we don't benefit using the same instance) 