### PR TITLE
better errors

### DIFF
--- a/__tests__/TokenGenerator/PasswordGenerator.test.js
+++ b/__tests__/TokenGenerator/PasswordGenerator.test.js
@@ -6,7 +6,7 @@ import {
   ForbiddenError,
   InternalServerError,
   ResourceNotFoundError,
-  AccessDeniedError,
+  UnauthorizedError,
 } from '../../src/Error';
 
 global.FormData = require('form-data');
@@ -88,7 +88,7 @@ describe('PasswordGenerator tests', () => {
     ]);
   });
 
-  test('test that refreshToken throws AccessDeniedError on 400', () => {
+  test('test that refreshToken throws UnauthorizedError on 400', () => {
     const tokenGenerator = new PasswordGenerator(tokenConfig);
 
     fetchMock.mock(() => true, oauthClientCredentialsMock);
@@ -102,7 +102,7 @@ describe('PasswordGenerator tests', () => {
 
     return generateTokenPromise.then(accessToken =>
       tokenGenerator.refreshToken(accessToken).catch(err => {
-        expect(err instanceof AccessDeniedError).toEqual(true);
+        expect(err instanceof UnauthorizedError).toEqual(true);
       })
     );
   });

--- a/__tests__/client/AbstractClient.test.js
+++ b/__tests__/client/AbstractClient.test.js
@@ -376,7 +376,7 @@ describe('Test errors', () => {
         errors.BadRequestError
       ),
       expect(SomeSdk.getRepository('test').find(401)).rejects.toBeInstanceOf(
-        errors.AccessDeniedError
+        errors.UnauthorizedError
       ),
       expect(SomeSdk.getRepository('test').find(403)).rejects.toBeInstanceOf(
         errors.ForbiddenError

--- a/src/Error.js
+++ b/src/Error.js
@@ -4,8 +4,8 @@
  */
 
 function HttpError(message, baseResponse) {
-  this.name = 'BadRequestError';
-  this.message = message || 'Bad request';
+  this.name = 'HttpError';
+  this.message = message || 'Http errort';
   this.baseResponse = baseResponse;
   this.stack = new Error().stack;
 }
@@ -23,14 +23,14 @@ BadRequestError.prototype = Object.create(HttpError.prototype);
 BadRequestError.prototype.constructor = BadRequestError;
 
 // 401
-function AccessDeniedError(message, baseResponse) {
-  this.name = 'AccessDeniedError';
-  this.message = message || 'Access denied';
+function UnauthorizedError(message, baseResponse) {
+  this.name = 'UnauthorizedError';
+  this.message = message || 'Unauthorized';
   this.baseResponse = baseResponse;
   this.stack = new Error().stack;
 }
-AccessDeniedError.prototype = Object.create(BadRequestError.prototype);
-AccessDeniedError.prototype.constructor = AccessDeniedError;
+UnauthorizedError.prototype = Object.create(BadRequestError.prototype);
+UnauthorizedError.prototype.constructor = UnauthorizedError;
 
 // 403
 function ForbiddenError(message, baseResponse) {
@@ -52,6 +52,16 @@ function ResourceNotFoundError(message, baseResponse) {
 ResourceNotFoundError.prototype = Object.create(BadRequestError.prototype);
 ResourceNotFoundError.prototype.constructor = ResourceNotFoundError;
 
+// 409
+function ConflictError(message, baseResponse) {
+  this.name = 'ConflictError';
+  this.message = message || 'Conflict detected';
+  this.baseResponse = baseResponse;
+  this.stack = new Error().stack;
+}
+ConflictError.prototype = Object.create(BadRequestError.prototype);
+ConflictError.prototype.constructor = ConflictError;
+
 // 500
 function InternalServerError(message, baseResponse) {
   this.name = 'InternalServerError';
@@ -64,11 +74,17 @@ InternalServerError.prototype.constructor = InternalServerError;
 
 function handleBadResponse(response) {
   switch (true) {
+    case response.status === 401:
+      throw new UnauthorizedError(null, response);
+
     case response.status === 403:
       throw new ForbiddenError(null, response);
 
     case response.status === 404:
       throw new ResourceNotFoundError(null, response);
+
+    case response.status === 409:
+      throw new ConflictError(null, response);
 
     case response.status >= 400 && response.status < 500:
       throw new BadRequestError(null, response);
@@ -77,13 +93,14 @@ function handleBadResponse(response) {
       throw new InternalServerError(null, response);
 
     default:
-      return new Error(`Unexpected error, status code is ${response.status}`);
+      return new HttpError(null, response);
   }
 }
 
 export {
-  AccessDeniedError,
+  UnauthorizedError,
   BadRequestError,
+  ConflictError,
   ForbiddenError,
   HttpError,
   InternalServerError,

--- a/src/TokenGenerator/ClientCredentialsGenerator.js
+++ b/src/TokenGenerator/ClientCredentialsGenerator.js
@@ -39,7 +39,7 @@ class ClientCredentialsGenerator extends AbstractTokenGenerator {
       method: 'POST',
       body: this.convertMapToFormData(parameters),
     }).then(response => {
-      if (response.status !== 200) {
+      if (response.status >= 400) {
         return handleBadResponse(response);
       }
 

--- a/src/TokenGenerator/PasswordGenerator.js
+++ b/src/TokenGenerator/PasswordGenerator.js
@@ -2,7 +2,7 @@ import URI from 'urijs';
 import AbstractTokenGenerator from './AbstractTokenGenerator';
 import { memoizePromise } from '../decorator';
 import {
-  AccessDeniedError,
+  UnauthorizedError,
   handleBadResponse,
   BadRequestError,
 } from '../Error';
@@ -59,8 +59,11 @@ class PasswordGenerator extends AbstractTokenGenerator {
     return this._doFetch(parameters)
       .then(response => response.clone().json())
       .catch(err => {
+        // bad params like wrong scopes sent to oauth server
+        // will generate a 400, we want final clients to consider it
+        // like 401 in order to take proper action
         if (err instanceof BadRequestError) {
-          throw new AccessDeniedError(err.message, err.baseResponse);
+          throw new UnauthorizedError(err.message, err.baseResponse);
         }
         throw err;
       });

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,12 @@
 import RestClientSdk from './RestClientSdk';
 import {
-  AccessDeniedError,
   BadRequestError,
+  ConflictError,
   ForbiddenError,
   HttpError,
   InternalServerError,
   ResourceNotFoundError,
+  UnauthorizedError,
 } from './Error';
 import AbstractClient from './client/AbstractClient';
 import TokenStorage from './TokenStorage';
@@ -28,8 +29,9 @@ export {
   ProvidedTokenGenerator,
   Serializer,
   TokenStorage,
-  AccessDeniedError,
+  UnauthorizedError,
   BadRequestError,
+  ConflictError,
   ForbiddenError,
   HttpError,
   InternalServerError,


### PR DESCRIPTION
The naming of errors was wrong as a response with status code 401 would generate an AccessDeniedError which naming is usually used for a 403. Rename AccessDeniedError => UnauthorizedError.

Default error sent by handleBadResponse is now HttpError containing the baseResponse like the others.

Add ConflictError to be able to react to 409s.