### PR TITLE
Sg set headers

### DIFF
--- a/__tests__/client/AbstractClient.test.js
+++ b/__tests__/client/AbstractClient.test.js
@@ -493,33 +493,98 @@ describe('Fix bugs', () => {
       });
   });
 
-  test('allow global client header override', () => {
+  test('allow passing request params in find', () => {
     fetchMock.mock(() => true, {
       '@id': '/v2/test/8',
       foo: 'bar',
     });
 
-    SomeSdk.getRepository('test').setHeaders({ foo: 'bar' });
-
     return SomeSdk.getRepository('test')
-      .find('/v2/test/8')
+      .find('/v2/test/8', {}, {}, { headers: { foo: 'bar' } })
       .then(() => {
         expect(fetchMock.lastOptions().headers.foo).toEqual('bar');
       });
   });
 
-  test('allow resetting global client header override', () => {
+  test('allow passing request params in findBy', () => {
+    fetchMock.mock(() => true, [
+      {
+        '@id': '/v2/test/8',
+        foo: 'bar',
+      },
+    ]);
+
+    return SomeSdk.getRepository('test')
+      .findBy({ id: '/v2/test/8' }, {}, { headers: { foo: 'bar' } })
+      .then(() => {
+        expect(fetchMock.lastOptions().headers.foo).toEqual('bar');
+      });
+  });
+
+  test('allow passing request params in findAll', () => {
+    fetchMock.mock(() => true, [
+      {
+        '@id': '/v2/test/8',
+        foo: 'bar',
+      },
+    ]);
+
+    return SomeSdk.getRepository('test')
+      .findAll({ id: '/v2/test/8' }, {}, { headers: { foo: 'bar' } })
+      .then(() => {
+        expect(fetchMock.lastOptions().headers.foo).toEqual('bar');
+      });
+  });
+
+  test('allow passing request params in create', () => {
     fetchMock.mock(() => true, {
       '@id': '/v2/test/8',
       foo: 'bar',
     });
 
-    SomeSdk.getRepository('test').setHeaders({});
+    return SomeSdk.getRepository('test')
+      .create({}, {}, {}, { headers: { foo: 'bar' } })
+      .then(() => {
+        expect(fetchMock.lastOptions().headers.foo).toEqual('bar');
+      });
+  });
+
+  // test('allow passing request params in update', () => {
+  //   fetchMock.mock(() => true, {
+  //     '@id': '/v2/test/8',
+  //     foo: 'bar',
+  //   });
+
+  //   return SomeSdk.getRepository('test')
+  //     .update({'@type': 'test'}, {}, { headers: { foo: 'bar' }})
+  //     .then(() => {
+  //       expect(fetchMock.lastOptions().headers.foo).toEqual('bar');
+  //     });
+  // });
+
+  // test('allow passing request params in delete', () => {
+  //   fetchMock.mock(() => true, {
+  //     '@id': '/v2/test/8',
+  //     foo: 'bar',
+  //   });
+
+  //   return SomeSdk.getRepository('test')
+  //     .find('/v2/test/8', {}, {}, { headers: { foo: 'bar' }})
+  //     .then(() => {
+  //       expect(fetchMock.lastOptions().headers.foo).toEqual('bar');
+  //     });
+  // });
+
+  test('allow overriding request params', () => {
+    fetchMock.mock(() => true, {
+      '@id': '/v2/test/8',
+      foo: 'bar',
+    });
 
     return SomeSdk.getRepository('test')
-      .find('/v2/test/8')
+      .find('/v2/test/8', {}, {}, { method: 'POST' })
       .then(() => {
-        expect(fetchMock.lastOptions().headers.foo).toBeUndefined();
+        expect(fetchMock.lastOptions().method).toEqual('POST');
       });
   });
 

--- a/__tests__/client/AbstractClient.test.js
+++ b/__tests__/client/AbstractClient.test.js
@@ -537,43 +537,45 @@ describe('Fix bugs', () => {
   });
 
   test('allow passing request params in create', () => {
-    fetchMock.mock(() => true, {
-      '@id': '/v2/test/8',
-      foo: 'bar',
-    });
+    const test = {
+      '@id': '/v2/tests/1',
+    };
+
+    fetchMock.mock(() => true, {});
 
     return SomeSdk.getRepository('test')
-      .create({}, {}, {}, { headers: { foo: 'bar' } })
+      .create(test, {}, {}, { headers: { foo: 'bar' } })
       .then(() => {
         expect(fetchMock.lastOptions().headers.foo).toEqual('bar');
       });
   });
 
-  // test('allow passing request params in update', () => {
-  //   fetchMock.mock(() => true, {
-  //     '@id': '/v2/test/8',
-  //     foo: 'bar',
-  //   });
+  test('allow passing request params in update', () => {
+    const test = {
+      '@id': '/v2/tests/1',
+    };
 
-  //   return SomeSdk.getRepository('test')
-  //     .update({'@type': 'test'}, {}, { headers: { foo: 'bar' }})
-  //     .then(() => {
-  //       expect(fetchMock.lastOptions().headers.foo).toEqual('bar');
-  //     });
-  // });
+    fetchMock.mock(() => true, {});
 
-  // test('allow passing request params in delete', () => {
-  //   fetchMock.mock(() => true, {
-  //     '@id': '/v2/test/8',
-  //     foo: 'bar',
-  //   });
+    return SomeSdk.getRepository('test')
+      .update(test, {}, { headers: { foo: 'bar' } })
+      .then(() => {
+        expect(fetchMock.lastOptions().headers.foo).toEqual('bar');
+      });
+  });
 
-  //   return SomeSdk.getRepository('test')
-  //     .find('/v2/test/8', {}, {}, { headers: { foo: 'bar' }})
-  //     .then(() => {
-  //       expect(fetchMock.lastOptions().headers.foo).toEqual('bar');
-  //     });
-  // });
+  test('allow passing request params in delete', () => {
+    fetchMock.mock(() => true, {});
+    const test = {
+      '@id': '/v2/tests/1',
+    };
+
+    return SomeSdk.getRepository('test')
+      .delete(test, { headers: { foo: 'bar' } })
+      .then(() => {
+        expect(fetchMock.lastOptions().headers.foo).toEqual('bar');
+      });
+  });
 
   test('allow overriding request params', () => {
     fetchMock.mock(() => true, {

--- a/__tests__/client/AbstractClient.test.js
+++ b/__tests__/client/AbstractClient.test.js
@@ -493,6 +493,36 @@ describe('Fix bugs', () => {
       });
   });
 
+  test('allow global client header override', () => {
+    fetchMock.mock(() => true, {
+      '@id': '/v2/test/8',
+      foo: 'bar',
+    });
+
+    SomeSdk.getRepository('test').setHeaders({ foo: 'bar' });
+
+    return SomeSdk.getRepository('test')
+      .find('/v2/test/8')
+      .then(() => {
+        expect(fetchMock.lastOptions().headers.foo).toEqual('bar');
+      });
+  });
+
+  test('allow resetting global client header override', () => {
+    fetchMock.mock(() => true, {
+      '@id': '/v2/test/8',
+      foo: 'bar',
+    });
+
+    SomeSdk.getRepository('test').setHeaders({});
+
+    return SomeSdk.getRepository('test')
+      .find('/v2/test/8')
+      .then(() => {
+        expect(fetchMock.lastOptions().headers.foo).toBeUndefined();
+      });
+  });
+
   test('check that the request done after refreshing a token contains the refreshed token', () => {
     fetchMock
       .mock({

--- a/src/client/AbstractClient.js
+++ b/src/client/AbstractClient.js
@@ -9,6 +9,11 @@ class AbstractClient {
     this._tokenStorage = sdk.tokenStorage;
     this.serializer = sdk.serializer;
     this.metadata = metadata;
+    this.headers = {};
+  }
+
+  setHeaders(headers = {}) {
+    this.headers = headers;
   }
 
   getDefaultParameters() {
@@ -285,7 +290,7 @@ class AbstractClient {
           }
           throw error;
         })
-        .catch((err) => {
+        .catch(err => {
           if (err instanceof OauthError) {
             throw err;
           }
@@ -322,6 +327,8 @@ class AbstractClient {
     } else {
       params = { headers: baseHeaders };
     }
+
+    params.headers = Object.assign(params.headers, this.headers);
 
     params.headers = this._removeUndefinedHeaders(params.headers);
 


### PR DESCRIPTION
Possibility to add headers on a client's scope (up to now it was only possible by passing a param object to authorizedFetch, and not possible to pass it to methods like find, create, etc... in clients)