### PR TITLE
memoize TokenStorage token generation functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- [BREAKING] UnitOfWork is disabled by default, one must pass a prop `unitOfWorkEnabled` with value true to the RestClientSdk's constructor in order to enable it
+- [BREAKING] UnitOfWork is disabled by default, one must add a prop `unitOfWorkEnabled` with value true to the config object passed to the RestClientSdk's constructor in order to enable it
 - TokenStorage's `generateToken` and `refreshToken` methods are now memoized in order to avoid bugs when making concurrent calls
 
 ## 5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## unreleased
+
+### Changed
+
+- [BREAKING] UnitOfWork is disabled by default, one must pass a prop `unitOfWorkEnabled` with value true to the RestClientSdk's constructor in order to enable it
+- TokenStorage's `generateToken` and `refreshToken` methods are now memoized in order to avoid bugs when making concurrent calls
+
 ## 5.0.0
 
 This release is a migration to TypeScript, but the API stay the same. The only breaking changes are more fixed bugs that might be breaking in really improbable case.

--- a/__tests__/UnitOfWork.test.js
+++ b/__tests__/UnitOfWork.test.js
@@ -1,13 +1,12 @@
 import { Map, Record } from 'immutable';
 import unitOfWorkMapping, {
   cartMetadata,
-  orderMetadata,
 } from '../__mocks__/unitOfWorkMapping';
 import UnitOfWork from '../src/UnitOfWork';
 
 let unitOfWork = null;
 beforeEach(() => {
-  unitOfWork = new UnitOfWork(unitOfWorkMapping);
+  unitOfWork = new UnitOfWork(unitOfWorkMapping, true);
 });
 describe('UnitOfWork', () => {
   test('register unit of work', () => {

--- a/__tests__/client/AbstractClient.test.js
+++ b/__tests__/client/AbstractClient.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 /* eslint-disable max-classes-per-file */
 /* eslint no-unused-vars: 0, no-underscore-dangle: 0 */
 import fetchMock from 'fetch-mock';
@@ -12,7 +11,6 @@ import RestClientSdk, {
   Mapping,
   ClassMetadata,
   Attribute,
-  Relation,
 } from '../../src/index';
 import tokenStorageMock from '../../__mocks__/tokenStorage';
 import MockStorage from '../../__mocks__/mockStorage';
@@ -48,7 +46,7 @@ class WeirdSerializer extends Serializer {
   }
 
   _addInfoToItem(item) {
-    return Object.assign({}, item, { customName: `${item.name}${item.name}` });
+    return { ...item, customName: `${item.name}${item.name}` };
   }
 }
 
@@ -88,7 +86,7 @@ mappingNoPrefix.setMapping([testMetadata, defParamMetadata, noAtIdMetadata]);
 
 const SomeSdk = new RestClientSdk(
   tokenStorageMock,
-  { path: 'api.me', scheme: 'https' },
+  { path: 'api.me', scheme: 'https', unitOfWorkEnabled: true },
   mapping
 );
 SomeSdk.tokenStorage.generateToken();
@@ -235,7 +233,7 @@ describe('Test Client', () => {
   test('handle entityFactory with a custom serializer', () => {
     const EntityFactorySdk = new RestClientSdk(
       tokenStorageMock,
-      { path: 'api.me', scheme: 'https' },
+      { path: 'api.me', scheme: 'https', unitOfWorkEnabled: true },
       mapping,
       new WeirdSerializer()
     );
@@ -311,7 +309,7 @@ describe('Test Client', () => {
 
     const SomeSdkNoPrefix = new RestClientSdk(
       tokenStorageMock,
-      { path: 'api.me', scheme: 'https' },
+      { path: 'api.me', scheme: 'https', unitOfWorkEnabled: true },
       mappingNoPrefix
     );
 
@@ -339,7 +337,12 @@ describe('Test Client', () => {
 
     const BasicAuthSdk = new RestClientSdk(
       tokenStorageMock,
-      { path: 'api.me', scheme: 'https', authorizationType: 'Basic' },
+      {
+        path: 'api.me',
+        scheme: 'https',
+        authorizationType: 'Basic',
+        unitOfWorkEnabled: true,
+      },
       mapping
     );
     BasicAuthSdk.tokenStorage.generateToken();
@@ -362,7 +365,12 @@ describe('Test Client', () => {
 
     const NoAuthSdk = new RestClientSdk(
       null,
-      { path: 'api.me', scheme: 'https', authorizationType: 'Basic' },
+      {
+        path: 'api.me',
+        scheme: 'https',
+        authorizationType: 'Basic',
+        unitOfWorkEnabled: true,
+      },
       mapping
     );
 
@@ -444,7 +452,7 @@ describe('Fix bugs', () => {
   test('generate good url', () => {
     const SomeInnerSdk = new RestClientSdk(
       tokenStorageMock,
-      { path: 'api.me', scheme: 'https' },
+      { path: 'api.me', scheme: 'https', unitOfWorkEnabled: true },
       mapping
     );
     SomeInnerSdk.tokenStorage.generateToken();
@@ -665,7 +673,7 @@ describe('Fix bugs', () => {
 
     const SomeInnerSdk = new RestClientSdk(
       new TokenStorage(tokenGenerator, storage),
-      { path: 'api.me', scheme: 'https' },
+      { path: 'api.me', scheme: 'https', unitOfWorkEnabled: true },
       mapping
     );
 
@@ -756,7 +764,7 @@ describe('Fix bugs', () => {
 
     const SomeInnerSdk = new RestClientSdk(
       new TokenStorage(tokenGenerator, storage),
-      { path: 'api.me', scheme: 'https' },
+      { path: 'api.me', scheme: 'https', unitOfWorkEnabled: true },
       mapping
     );
 
@@ -833,7 +841,7 @@ describe('Fix bugs', () => {
 
     const SomeInnerSdk = new RestClientSdk(
       new TokenStorage(tokenGenerator, storage),
-      { path: 'api.me', scheme: 'https' },
+      { path: 'api.me', scheme: 'https', unitOfWorkEnabled: true },
       mapping
     );
 
@@ -857,7 +865,7 @@ describe('Test unit of work', () => {
   beforeEach(() => {
     unitOfWorkSdk = new RestClientSdk(
       tokenStorageMock,
-      { path: 'api.me', scheme: 'https' },
+      { path: 'api.me', scheme: 'https', unitOfWorkEnabled: true },
       unitOfWorkMapping
     );
   });

--- a/src/RestClientSdk.ts
+++ b/src/RestClientSdk.ts
@@ -54,7 +54,7 @@ class RestClientSdk<M extends SdkMetadata>
     this.serializer = serializer;
     this.mapping = mapping;
 
-    this.unitOfWork = new UnitOfWork(this.mapping);
+    this.unitOfWork = new UnitOfWork(this.mapping, this.config.unitOfWorkEnabled);
 
     this.#repositoryList = {};
   }

--- a/src/RestClientSdkInterface.ts
+++ b/src/RestClientSdkInterface.ts
@@ -11,6 +11,7 @@ export type Config = {
   segment?: string;
   authorizationType?: string; // default to "Bearer", but can be "Basic" or anything
   useDefaultParameters?: boolean;
+  unitOfWorkEnabled?: boolean;
 };
 
 export default interface RestClientSdkInterface<M extends SdkMetadata> {

--- a/src/TokenStorage.ts
+++ b/src/TokenStorage.ts
@@ -2,6 +2,7 @@
 import TokenGeneratorInterface from './TokenGenerator/TokenGeneratorInterface';
 import { Token } from './TokenGenerator/types';
 import AsyncStorageInterface from './AsyncStorageInterface';
+import { memoizePromise } from './decorator';
 import type TokenStorageInterface from './TokenStorageInterface';
 
 interface HasExpiresAt {
@@ -26,6 +27,9 @@ class TokenStorage<T extends Token> implements TokenStorageInterface<T> {
     this.#hasATokenBeenGenerated = false;
     this.setAsyncStorage(asyncStorage);
     this.accessTokenKey = accessTokenKey;
+
+    this.generateToken = memoizePromise(this.generateToken);
+    this.refreshToken = memoizePromise(this.refreshToken);
   }
 
   setAsyncStorage(asyncStorage: AsyncStorageInterface): void {

--- a/src/UnitOfWork.ts
+++ b/src/UnitOfWork.ts
@@ -99,13 +99,19 @@ class UnitOfWork {
 
   #storage: { [key in Id]: Record<string, unknown> };
 
-  constructor(mapping: Mapping) {
+  #enabled: boolean;
+
+  constructor(mapping: Mapping, enabled = false) {
     this.mapping = mapping;
 
+    this.#enabled = enabled;
     this.#storage = {};
   }
 
   registerClean(id: Id, entity: Record<string, unknown>): void {
+    if (!this.#enabled) {
+      return;
+    }
     if (isImmutable(entity)) {
       this.#storage[id] = entity;
     } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,11 @@ import Attribute from './Mapping/Attribute';
 import Relation from './Mapping/Relation';
 import type { Token } from './TokenGenerator/types';
 import type { SdkMetadata } from './RestClientSdk';
+
+// eslint-disable-next-line import/no-duplicates
 import type RestClientSdkInterface from './RestClientSdkInterface';
+// eslint-disable-next-line import/no-duplicates
+import type { Config } from './RestClientSdkInterface';
 import type TokenStorageInterface from './TokenStorageInterface';
 import type TokenGeneratorInterface from './TokenGenerator/TokenGeneratorInterface';
 import type AsyncStorageInterface from './AsyncStorageInterface';
@@ -57,6 +61,7 @@ export {
 export type {
   SerializerInterface,
   Token,
+  Config,
   SdkMetadata,
   RestClientSdkInterface,
   TokenStorageInterface,


### PR DESCRIPTION
memoize TokenStorage token generation functions to avoid concurrent calls incoherence

We were already memoizing the _doFetch call of PasswordGenerator and the generateToken call of ClientCredentialsGenerator but it is not enough since async stuff happens before and after the call, like getting or storing the token which leads to revoked refresh_token being sent to POST /token when we want to refresh the token, and invalid_grant error with message "invalid refresh token".

We memoize at the top level in order to encapsulate the whole operation. 

[BREAKING] UnitOfWork is disabled by default, one must pass a prop `unitOfWorkEnabled` with value true to the RestClientSdk's constructor in order to enable it