### PR TITLE
Optimize if UnitOfWork 

### DIFF
--- a/src/RestClientSdk.ts
+++ b/src/RestClientSdk.ts
@@ -77,7 +77,11 @@ class RestClientSdk<M extends SdkMetadata>
       }
 
       // eslint-disable-next-line new-cap
-      this.#repositoryList[key] = generateRepository<M[K]>(this, metadata);
+      this.#repositoryList[key] = generateRepository<M[K]>(
+        this,
+        metadata,
+        this.config.unitOfWorkEnabled
+      );
     }
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/client/AbstractClient.ts
+++ b/src/client/AbstractClient.ts
@@ -265,17 +265,19 @@ class AbstractClient<D extends MetadataDefinition> {
             response
           ) as D['list'];
 
-          // eslint-disable-next-line no-restricted-syntax
-          for (const decodedItem of itemList) {
-            const identifier = this._getEntityIdentifier(decodedItem);
-            const normalizedItem = this.serializer.normalizeItem(
-              decodedItem,
-              this.metadata
-            );
+          if (this.#isUnitOfWorkEnabled) {
+            // eslint-disable-next-line no-restricted-syntax
+            for (const decodedItem of itemList) {
+              const identifier = this._getEntityIdentifier(decodedItem);
+              const normalizedItem = this.serializer.normalizeItem(
+                decodedItem,
+                this.metadata
+              );
 
-            // then we register the re-normalized item
-            if (this.#isUnitOfWorkEnabled && identifier !== null) {
-              this.sdk.unitOfWork.registerClean(identifier, normalizedItem);
+              // then we register the re-normalized item
+              if (identifier !== null) {
+                this.sdk.unitOfWork.registerClean(identifier, normalizedItem);
+              }
             }
           }
 


### PR DESCRIPTION
Avoid useless call if unitOfWork is disabled.

If unitOfWork is disabled in the global configuration, then it will be disabled for  all call to `getRepository`.

It will probably throw fail with `create` and `update` calls. See https://github.com/mapado/rest-client-js-sdk/issues/94