### PR TITLE
add a helper to get JSON of an HttpError

### DIFF
--- a/src/ErrorFactory.ts
+++ b/src/ErrorFactory.ts
@@ -23,6 +23,10 @@ class HttpError extends Error {
     this.name = 'HttpError';
     this.baseResponse = baseResponse;
   }
+
+  public async getBaseResponseJson(): Promise<Record<string, unknown>> {
+    return this.baseResponse.json();
+  }
 }
 
 class OauthError extends Error {

--- a/src/ErrorFactory.ts
+++ b/src/ErrorFactory.ts
@@ -24,7 +24,7 @@ class HttpError extends Error {
     this.baseResponse = baseResponse;
   }
 
-  public async getBaseResponseJson(): Promise<Record<string, unknown>> {
+  public async responseJson(): Promise<Record<string, unknown>> {
     return this.baseResponse.json();
   }
 }

--- a/src/ErrorFactory.ts
+++ b/src/ErrorFactory.ts
@@ -24,6 +24,9 @@ class HttpError extends Error {
     this.baseResponse = baseResponse;
   }
 
+  /**
+   * Get the JSON of the baseResponse directly, if possible
+   */
   public async responseJson(): Promise<Record<string, unknown>> {
     return this.baseResponse.json();
   }


### PR DESCRIPTION
Reflexion after [an internal review](https://github.com/mapado/desk/pull/1891#pullrequestreview-1197789419) to add a helper function to get the Json of an error response.

By seeing the diff, I wonder if its really useful 🤔 :

```diff
  if (error instanceof BadRequestError) {
-   return error.baseResponse.json().then((errorJson) => {
+   return error.responseJson().then((errorJson) => {
```