### PR TITLE
abstractClient: fix makeUri method

### DIFF
--- a/__tests__/client/AbstractClient.test.js
+++ b/__tests__/client/AbstractClient.test.js
@@ -461,6 +461,27 @@ describe('Fix bugs', () => {
     ).toEqual('https://api.me/v2/foo');
   });
 
+  test('generate good url when sdk mapping idPrefix contains long path', () => {
+    const mapping = new Mapping('/api/v2');
+    mapping.setMapping([testMetadata, defParamMetadata, noAtIdMetadata]);
+    mappingNoPrefix.setMapping([
+      testMetadata,
+      defParamMetadata,
+      noAtIdMetadata,
+    ]);
+
+    const SomeInnerSdk = new RestClientSdk(
+      tokenStorageMock,
+      { path: 'api.me', scheme: 'https', unitOfWorkEnabled: true },
+      mapping
+    );
+    SomeInnerSdk.tokenStorage.generateToken();
+
+    expect(
+      SomeInnerSdk.getRepository('test').makeUri('/api/v2/foo').toString()
+    ).toEqual('https://api.me/api/v2/foo');
+  });
+
   test('allow base header override', () => {
     fetchMock.mock(() => true, {
       '@id': '/v2/test/8',

--- a/src/client/AbstractClient.ts
+++ b/src/client/AbstractClient.ts
@@ -322,7 +322,8 @@ class AbstractClient<D extends MetadataDefinition> {
 
     if (this.sdk.mapping.idPrefix) {
       const segments = url.segment();
-      if (`/${segments[0]}` !== this.sdk.mapping.idPrefix) {
+
+      if (!url.pathname().startsWith(this.sdk.mapping.idPrefix)) {
         segments.unshift(this.sdk.mapping.idPrefix);
         url.segment(segments);
       }
@@ -491,7 +492,7 @@ class AbstractClient<D extends MetadataDefinition> {
       params.headers = removeUndefinedHeaders(params.headers);
     }
 
-    let logId: undefined|string;
+    let logId: undefined | string;
     if (this.sdk.logger) {
       logId = this.sdk.logger.logRequest({ url: input, ...params });
     }


### PR DESCRIPTION

### New behavior

We update makeUri method to check the beginning of URI pathname instead of just the first segment of the URI.

Checking only the first segment of URI can lead to errors since the default sdk prefix can be more than one segment.

### Current behavior

Check only the first segment of an URI

### Task

#3cxgjva

<!--
### Contexte

Utiliser ou créer l'un des labels suivants pour spécifier le périmètre et le type de la Pull Request :

- "scope: pompier", "scope: focus", "scope: tâche annexe"
- "type: bugfix", "type: feature", "type: poc"

Voir https://github.com/mapado/ticketing/labels pour un exemple

### Autres informations
-->
