### PR TITLE
Revert "Migrate from multipart/form-data to application/x-www-form-urlencoded"

### DIFF
--- a/__tests__/TokenGenerator/AbstractTokenGenerator.test.js
+++ b/__tests__/TokenGenerator/AbstractTokenGenerator.test.js
@@ -1,0 +1,27 @@
+import { AbstractTokenGenerator } from '../../src';
+
+describe('AbstractTokenGenerator tests', () => {
+  // test('contains all methods', () => {
+  //   const tokenGenerator = new AbstractTokenGenerator();
+
+  //   expect(tokenGenerator.checkTokenGeneratorConfig).not.toThrowError(Error);
+  //   expect(tokenGenerator.generateToken).toThrowError(Error);
+  //   expect(tokenGenerator.refreshToken).toThrowError(Error);
+  // });
+
+  test('test convert map to FormData', () => {
+    const tokenGenerator = new AbstractTokenGenerator();
+
+    const formData = tokenGenerator.convertMapToFormData({
+      a: 'abc',
+      foo: 'bar',
+    });
+
+    /* eslint-disable no-underscore-dangle */
+    expect(formData._streams[0]).toContain('name="a"');
+    expect(formData._streams[1]).toBe('abc');
+    expect(formData._streams[3]).toContain('name="foo"');
+    expect(formData._streams[4]).toBe('bar');
+    /* eslint-enable no-underscore-dangle */
+  });
+});

--- a/__tests__/TokenGenerator/AuthorizationCodeFlowTokenGenerator.ts
+++ b/__tests__/TokenGenerator/AuthorizationCodeFlowTokenGenerator.ts
@@ -18,6 +18,7 @@ import {
 global.fetch = require('jest-fetch-mock');
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error -- Form form data
+global.FormData = require('form-data');
 
 const tokenConfig = {
   path: 'oauth.me',

--- a/__tests__/TokenStorage.test.js
+++ b/__tests__/TokenStorage.test.js
@@ -224,14 +224,12 @@ describe('Oauth token generation error', () => {
       this.error = error;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     generateToken(parameters) {
       return new Promise((resolve) => {
         resolve(new Response(this.status, { error: this.error }));
       });
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     refreshToken(accessToken, parameters) {
       return new Promise((resolve) => {
         resolve(new Response(this.status, { error: this.error }));

--- a/__tests__/client/AbstractClient.test.js
+++ b/__tests__/client/AbstractClient.test.js
@@ -628,8 +628,7 @@ describe('Fix bugs', () => {
       .mock({
         name: 'generate_token',
         matcher: (url, opts) =>
-          url === 'https://oauth.me/' &&
-          opts.body.get('grant_type') === 'password',
+          url === 'https://oauth.me/' && opts.body._streams[7] === 'password',
         response: {
           body: {
             access_token: 'an_access_token',
@@ -643,12 +642,9 @@ describe('Fix bugs', () => {
       })
       .mock({
         name: 'refresh_token',
-        matcher: (url, opts) => {
-          return (
-            url === 'https://oauth.me/' &&
-            opts.body?.get('refresh_token') === 'refresh_token'
-          );
-        },
+        matcher: (url, opts) =>
+          url === 'https://oauth.me/' &&
+          opts.body._streams[1].match('refresh_token'),
         response: {
           body: {
             access_token: 'a_refreshed_token',
@@ -726,8 +722,7 @@ describe('Fix bugs', () => {
       .mock({
         name: 'generate_token',
         matcher: (url, opts) =>
-          url === 'https://oauth.me/' &&
-          opts.body.get('grant_type') === 'password',
+          url === 'https://oauth.me/' && opts.body._streams[7] === 'password',
         response: {
           body: {
             access_token: 'an_access_token',
@@ -743,7 +738,7 @@ describe('Fix bugs', () => {
         name: 'refresh_token',
         matcher: (url, opts) =>
           url === 'https://oauth.me/' &&
-          opts.body.get('refresh_token') === 'refresh_token',
+          opts.body._streams[1].match('refresh_token'),
         response: {
           body: {
             access_token: 'a_refreshed_token',
@@ -814,8 +809,7 @@ describe('Fix bugs', () => {
       .mock({
         name: 'generate_token',
         matcher: (url, opts) =>
-          url === 'https://oauth.me/' &&
-          opts.body.get('grant_type') === 'password',
+          url === 'https://oauth.me/' && opts.body._streams[7] === 'password',
         response: {
           body: {
             access_token: 'an_access_token',
@@ -831,7 +825,7 @@ describe('Fix bugs', () => {
         name: 'refresh_token',
         matcher: (url, opts) =>
           url === 'https://oauth.me/' &&
-          opts.body.get('refresh_token') === 'refresh_token',
+          opts.body._streams[1].match('refresh_token'),
         response: {
           body: {
             access_token: 'a_refreshed_token',
@@ -968,12 +962,12 @@ describe('Test unit of work', () => {
     const cart = await repo.find('/v12/carts/1');
     cart.status = 'foo';
 
-    await repo.update(cart);
+    let updatedCart = await repo.update(cart);
     expect(findLastOptions('put_cart').body).toEqual(
       JSON.stringify({ status: 'foo' })
     );
 
-    await repo.update(cart);
+    updatedCart = await repo.update(cart);
     expect(findLastOptions('put_cart').body).toEqual('{}');
   });
 
@@ -1013,7 +1007,7 @@ describe('Test unit of work', () => {
       });
 
     const repo = unitOfWorkSdk.getRepository('carts');
-    await repo.find('/v12/carts/1');
+    const cart = await repo.find('/v12/carts/1');
 
     await repo.update({ '@id': '/v12/carts/1', status: null });
     expect(findLastOptions('put_cart').body).toEqual(
@@ -1271,7 +1265,7 @@ describe('Test unit of work', () => {
     };
 
     const repo = unitOfWorkSdk.getRepository('carts');
-    await repo.create(cartToPost);
+    const cart = await repo.create(cartToPost);
 
     expect(fetchMock.lastOptions().body).toEqual(
       JSON.stringify({ order: { '@id': '/v12/orders/1', status: 'waiting' } })
@@ -1359,7 +1353,7 @@ describe('Test unit of work', () => {
 
       cartToPut.set('status', 'refunded');
 
-      await unitOfWorkSdk.getRepository('carts').update(cartToPut);
+      const cart = await unitOfWorkSdk.getRepository('carts').update(cartToPut);
 
       expect(fetchMock.lastOptions().body).toEqual(
         JSON.stringify({

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^2.5.0 || ^1.7.0",
     "fetch-mock": "^9",
+    "form-data": "^3.0.0",
     "husky": "^4.2.3",
     "immutable": "^4.0.0-rc.12",
     "jest": "^25.2.7",

--- a/setupJest.js
+++ b/setupJest.js
@@ -1,6 +1,8 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 
+global.FormData = require('form-data');
+
 let dateNowSpy;
 export const NOW_TIMESTAMP_MOCK = 1487076708000;
 

--- a/src/TokenGenerator/AbstractTokenGenerator.ts
+++ b/src/TokenGenerator/AbstractTokenGenerator.ts
@@ -72,6 +72,24 @@ abstract class AbstractTokenGenerator<T extends Token, C>
       });
   }
 
+  protected convertMapToFormData(parameters: {
+    [key: string]: undefined | string | Blob;
+  }): FormData {
+    const keys = Object.keys(parameters);
+
+    const formData = new FormData();
+
+    keys.forEach((key) => {
+      const value = parameters[key];
+
+      if (typeof value !== 'undefined') {
+        formData.append(key, value);
+      }
+    });
+
+    return formData;
+  }
+
   protected generateUrlFromConfig(config: UrlConfig): string {
     const uri = new URI(`${config.scheme}://${config.path}`);
 

--- a/src/TokenGenerator/AuthorizationCodeFlowTokenGenerator.ts
+++ b/src/TokenGenerator/AuthorizationCodeFlowTokenGenerator.ts
@@ -44,20 +44,23 @@ class AuthorizationCodeFlowTokenGenerator extends AbstractTokenGenerator<
   ): Promise<AuthorizationCodeFlowResponse> {
     this._checkGenerateParameters(parameters);
 
+    const { code } = parameters;
+
+    const body = new FormData();
+    body.append('grant_type', 'authorization_code');
+    body.append('client_id', this.tokenGeneratorConfig.clientId);
+    body.append(
+      'client_secret',
+      this.tokenGeneratorConfig.clientSecret // TODO : secure this
+    );
+    body.append('redirect_uri', this.tokenGeneratorConfig.redirectUri);
+    body.append('code', code);
+
     const url = this.generateUrlFromConfig(this.tokenGeneratorConfig);
 
     const params = {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      body: new URLSearchParams({
-        grant_type: 'authorization_code',
-        client_id: this.tokenGeneratorConfig.clientId,
-        client_secret: this.tokenGeneratorConfig.clientSecret, // TODO : secure this ?
-        redirect_uri: this.tokenGeneratorConfig.redirectUri,
-        code: parameters.code,
-      }),
+      body,
     };
 
     if (this.logger) {
@@ -84,19 +87,17 @@ class AuthorizationCodeFlowTokenGenerator extends AbstractTokenGenerator<
       throw new Error('Unable to refreshToken as there are no refresh_token');
     }
 
+    const body = new FormData();
+    body.append('client_id', this.tokenGeneratorConfig.clientId);
+    body.append('client_secret', this.tokenGeneratorConfig.clientSecret);
+    body.append('grant_type', 'refresh_token');
+    body.append('refresh_token', oldAccessToken.refresh_token);
+
     const url = this.generateUrlFromConfig(this.tokenGeneratorConfig);
 
     const params = {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      body: new URLSearchParams({
-        grant_type: 'refresh_token',
-        client_id: this.tokenGeneratorConfig.clientId,
-        client_secret: this.tokenGeneratorConfig.clientSecret,
-        refresh_token: oldAccessToken.refresh_token,
-      }),
+      body,
     };
 
     if (this.logger) {

--- a/src/TokenGenerator/TokenGeneratorInterface.ts
+++ b/src/TokenGenerator/TokenGeneratorInterface.ts
@@ -1,4 +1,4 @@
-import { Token, TokenBody, TokenResponse } from './types';
+import { ErrorBody, Token, TokenBody, TokenResponse } from './types';
 
 /** @deprecated */
 export type TokenBodyReturn<T> = TokenBody<T>;

--- a/src/TokenGenerator/types.ts
+++ b/src/TokenGenerator/types.ts
@@ -31,3 +31,12 @@ export type TokenBody<T> = T | ErrorBody;
 export interface TokenResponse<T extends Token> extends Response {
   json(): Promise<TokenBody<T>>;
 }
+
+/**
+ * See {@link https://tools.ietf.org/html/rfc6749#section-6 Refreshing an access token}
+ */
+export type RefreshTokenParameters = {
+  grant_type: 'refresh_token';
+  refresh_token: string;
+  scope?: string;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import type {
   ErrorBody,
   TokenBody,
   TokenResponse,
+  RefreshTokenParameters,
 } from './TokenGenerator/types';
 
 import type { SdkMetadata, MetadataDefinition } from './RestClientSdk';
@@ -78,6 +79,7 @@ export type {
   TokenResponse,
   TokenBody,
   HasExpiresAt,
+  RefreshTokenParameters,
   Config,
   SdkMetadata,
   RestClientSdkInterface,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2139,7 +2139,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -3053,6 +3053,15 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
+  integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"


### PR DESCRIPTION
### Nouveau comportement

Use multipart/form-data to send oauth params again since react-native is not compatible with URLSearchParams API

This reverts commit 823f2440820c9c105977b1e99468d9d8c280db0c.

### Comportement actuel

Oauth params are converted with URLSearchParams and sent using application/x-www-form-urlencoded
