### PR TITLE
Remove referer as it is handled by the browser

### DIFF
--- a/__tests__/client/AbstractClient.test.js
+++ b/__tests__/client/AbstractClient.test.js
@@ -518,7 +518,6 @@ describe('Fix bugs', () => {
       .then(() => {
         expect(Object.keys(fetchMock.lastOptions().headers)).toEqual([
           'Authorization',
-          'Referer',
           'bar',
           'baz',
           'bad',

--- a/src/client/AbstractClient.ts
+++ b/src/client/AbstractClient.ts
@@ -472,12 +472,6 @@ class AbstractClient<D extends MetadataDefinition> {
       baseHeaders.Authorization = `${this.sdk.config.authorizationType} ${accessToken}`;
     }
 
-    const currentUri =
-      typeof window === 'object' && window.location && window.location.href;
-    if (currentUri) {
-      baseHeaders.Referer = currentUri;
-    }
-
     if (params) {
       if (!params.headers) {
         params.headers = {};


### PR DESCRIPTION
Referer header is a [forbidden header](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name), so we can not override it. That is the browser work.

A possible solution might be to use [the referrer policy](https://developer.mozilla.org/fr/docs/Web/HTTP/Headers/Referrer-Policy) (like `no-referrer-when-downgrade`) if you want to do cross-site requests