### PR TITLE
The Content-Type entity-header field indicates the media type of the …

### DIFF
--- a/src/client/AbstractClient.ts
+++ b/src/client/AbstractClient.ts
@@ -465,7 +465,7 @@ class AbstractClient<D extends MetadataDefinition> {
     let params = requestParams;
     let baseHeaders: HeadersInit = {};
 
-    if (params.method !== 'GET') {
+    if (params.method !== 'GET' || (params.method !== 'GET' && params.method !== 'DELETE')) {
       baseHeaders = {
         'Content-Type': 'application/json',
       };

--- a/src/client/AbstractClient.ts
+++ b/src/client/AbstractClient.ts
@@ -463,10 +463,13 @@ class AbstractClient<D extends MetadataDefinition> {
     requestParams: RequestInit
   ): Promise<Response> {
     let params = requestParams;
+    let baseHeaders: HeadersInit = {};
 
-    const baseHeaders: HeadersInit = {
-      'Content-Type': 'application/json',
-    };
+    if (params.method !== 'GET') {
+      baseHeaders = {
+        'Content-Type': 'application/json',
+      };
+    }
 
     if (accessToken) {
       baseHeaders.Authorization = `${this.sdk.config.authorizationType} ${accessToken}`;


### PR DESCRIPTION
…entity-body sent to the recipient. In our case it provides a 400 with some api

### Comportement actuel
Actuellement on a une 400 lorsqu'on fait un search sur l'api sur certaines api. Pour une raison inconnu puisque ça devait marcher maintenant (maj sf ?)

### Nouveau comportement
Le fait de ne pas envoyer le content-type dans le cadre d'un get permet de corriger l'erreur.

Est-ce qu'il y aurait pas des cas ou on en a besoin ? des api mal conçus ?
 
#86bx4ar7t