### PR TITLE
allow calling create, update, delete with a disabled unitOfWork

### DIFF
--- a/__tests__/client/AbstractClient.test.js
+++ b/__tests__/client/AbstractClient.test.js
@@ -1115,9 +1115,15 @@ describe('Test unit of work', () => {
 
     const repo = unitOfWorkSdk.getRepository('carts');
 
-    expect(() => repo.withUnitOfWork(false).create({})).toThrow();
-    expect(() => repo.withUnitOfWork(false).update({})).toThrow();
-    expect(() => repo.withUnitOfWork(false).delete({})).toThrow();
+    expect(() => repo.withUnitOfWork(false).create({})).toThrowError(
+      'UnitOfWork can be deactivated only on find* methods (for now). If you think this should be authorized, please report in https://git.io/JkYTO'
+    );
+    expect(() => repo.withUnitOfWork(false).update({})).toThrowError(
+      'UnitOfWork can be deactivated only on find* methods (for now). If you think this should be authorized, please report in https://git.io/JkYTO'
+    );
+    expect(() => repo.withUnitOfWork(false).delete({})).toThrowError(
+      'UnitOfWork can be deactivated only on find* methods (for now). If you think this should be authorized, please report in https://git.io/JkYTO'
+    );
   });
 
   test('withUnitOfWork should return different instance', () => {

--- a/src/client/AbstractClient.ts
+++ b/src/client/AbstractClient.ts
@@ -223,8 +223,6 @@ class AbstractClient<D extends MetadataDefinition> {
    * @param {Record<string, unknown>} requestParams parameters that will be send as second parameter to the `fetch` call
    */
   delete(entity: D['entity'], requestParams = {}): Promise<Response> {
-    this._throwIfUnitOfWorkIsDisabled();
-
     const url = this.getEntityURI(entity);
     const identifier = this._getEntityIdentifier(entity);
 

--- a/src/client/AbstractClient.ts
+++ b/src/client/AbstractClient.ts
@@ -143,8 +143,6 @@ class AbstractClient<D extends MetadataDefinition> {
     pathParameters: Record<string, unknown> = {},
     requestParams: Record<string, unknown> = {}
   ): Promise<D['entity']> {
-    this._throwIfUnitOfWorkIsDisabled();
-
     const url = new URI(this.getPathBase(pathParameters));
     url.addSearch(queryParam);
 
@@ -518,18 +516,6 @@ class AbstractClient<D extends MetadataDefinition> {
     // @ts-ignore
     return object[idKey];
   }
-
-  private _throwIfUnitOfWorkIsDisabled(): void {
-    if (!this.#isUnitOfWorkEnabled) {
-      throw new Error(
-        'UnitOfWork can be deactivated only on find* methods (for now). If you think this should be authorized, please report in https://git.io/JkYTO'
-      );
-    }
-  }
 }
-
-type Headers = {
-  [key: string]: unknown;
-};
 
 export default AbstractClient;

--- a/src/client/AbstractClient.ts
+++ b/src/client/AbstractClient.ts
@@ -182,8 +182,6 @@ class AbstractClient<D extends MetadataDefinition> {
     queryParam: Record<string, unknown> = {},
     requestParams: Record<string, unknown> = {}
   ): Promise<D['entity']> {
-    this._throwIfUnitOfWorkIsDisabled();
-
     const url = new URI(this.getEntityURI(entity));
     url.addSearch(queryParam);
 


### PR DESCRIPTION
Fixes #94 

Copying from [here](https://github.com/mapado/rest-client-js-sdk/issues/94#issuecomment-1979065935):

We might want to deactivate the unitOfWork when we don't care about the result of the `create`, `update` or `delete` method.

Imagine a call that does fetch a item:

```ts
const item = await repository.find(1, { fields: '@id,name,type' });
```

later, we do have a modal that allow to change the name, but we don't care about the return

```ts
await repository.update(item.set('name', 'new name'), { fields: '@id' });
```

The unitOfWork will register the data with only the `@id`.

If later call a "type changer":


```ts
await repository.update(item.set('type', 'new type'), { fields: '@id' });
```

The `getDirtyData` will return that only the `@id` is known, and then send a call with:
```ts
{
  name: 'new name',
  type: 'new type',
}
```

We might want to disable the unit of work when "updating", as we do disable it for find method (a put is "just" a get that change some data before).

