### PR TITLE
Handle error that should trigger a refresh token

### DIFF
--- a/__tests__/client/AbstractClient.test.js
+++ b/__tests__/client/AbstractClient.test.js
@@ -668,7 +668,7 @@ describe('Fix bugs', () => {
         response: {
           status: 401,
           body: {
-            error: 'invalid_grant',
+            error: 'access_denied',
             error_description: 'The access token provided has expired.',
           },
         },

--- a/src/client/AbstractClient.ts
+++ b/src/client/AbstractClient.ts
@@ -437,7 +437,10 @@ class AbstractClient<D extends MetadataDefinition> {
       return response
         .json()
         .then((body) => {
-          if (this.#tokenStorage && body.error === 'invalid_grant') {
+          if (
+            this.#tokenStorage &&
+            (body.error === 'invalid_scope' || body.error === 'access_denied')
+          ) {
             return this._refreshTokenAndRefetch(input, requestParams);
           }
           throw error;


### PR DESCRIPTION
### Comportement actuel

`invalid_grant` is never returned by our API and should not trigger a refresh_token. See https://www.rfc-editor.org/rfc/rfc6749#section-5.2

### Nouveau comportement

Update error body that should trigger a refresh
