### PR TITLE
Add a `onRefreshTokenFailure` method to sdk config when refresh token triggers a 401 error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Add a `onRefreshTokenFailure` method to sdk config when refresh token triggers a 401 error. [#143](https://github.com/mapado/rest-client-js-sdk/pull/143)
+
 ## 7.0.3
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ const config = {
   authorizationType: 'Bearer', // default to "Bearer", but can be "Basic" or anything
   useDefaultParameters: true,
   unitOfWorkEnabled: true, // if key is missing, UnitOfWork will be disabled by default
+  onRefreshTokenFailure: () => {
+    // do something when the refresh token fails
+  },
 }; // path and scheme are mandatory
 
 const sdk = new RestClientSdk(tokenStorage, config, mapping);

--- a/__mocks__/mockStorage.js
+++ b/__mocks__/mockStorage.js
@@ -11,4 +11,8 @@ export default class Storage {
     // eslint-disable-next-line no-return-assign
     return Promise.resolve((this._map[key] = value));
   }
+
+  removeItem(key) {
+    return Promise.resolve(delete this._map[key]);
+  }
 }

--- a/src/RestClientSdkInterface.ts
+++ b/src/RestClientSdkInterface.ts
@@ -14,6 +14,7 @@ export type Config = {
   useDefaultParameters?: boolean;
   unitOfWorkEnabled?: boolean;
   loggerEnabled?: boolean;
+  onRefreshTokenFailure?: (error: Error) => void;
 };
 
 export default interface RestClientSdkInterface<M extends SdkMetadata> {

--- a/src/TokenStorage.ts
+++ b/src/TokenStorage.ts
@@ -193,7 +193,7 @@ class TokenStorage<T extends Token> implements TokenStorageInterface<T> {
         .then((body) => {
           if (isOauthError(body)) {
             // throw error if response body is an oauth error
-            manageOauthError(body, response);
+            manageOauthError(body, originalResponse);
           } else if (response.status >= 400) {
             // throw an error if response status code is an "error" status code
             throw getHttpErrorFromResponse(originalResponse);


### PR DESCRIPTION
If a refresh_token is invalid, we can not handle automatic refresh (obviously !).

We add a config parameter `onRefreshTokenFailure` to let the client do what he wants in that case.