### PR TITLE
find diff for array values

### DIFF
--- a/__mocks__/unitOfWorkMapping.js
+++ b/__mocks__/unitOfWorkMapping.js
@@ -7,6 +7,7 @@ cartMetadata.setAttributeList([
   new Attribute('clientPhoneNumber', 'clientPhoneNumber', 'phone_number'),
   new Attribute('createdAt', 'createdAt', 'datetime'),
   new Attribute('data', 'data', 'object'),
+  new Attribute('codeList', 'codeList', 'array'),
 ]);
 cartMetadata.setRelationList([
   new Relation(

--- a/__tests__/UnitOfWork.test.js
+++ b/__tests__/UnitOfWork.test.js
@@ -110,49 +110,6 @@ describe('UnitOfWork', () => {
         cartMetadata
       )
     ).toEqual({ '@id': '/v12/carts/2', status: 'payed' });
-
-    expect(
-      unitOfWork.getDirtyData(
-        {
-          '@id': '/v12/carts/1',
-          status: 'payed',
-          data: {
-            foo: 'bar',
-            loo: 'baz',
-          },
-        },
-        {
-          '@id': '/v12/carts/1',
-          status: 'payed',
-          data: {
-            foo: 'bar',
-          },
-        },
-        cartMetadata
-      )
-    ).toEqual({ data: { foo: 'bar', loo: 'baz' } });
-
-    expect(
-      unitOfWork.getDirtyData(
-        {
-          '@id': '/v12/carts/1',
-          status: 'payed',
-          data: {
-            foo: 'bar',
-            bad: 'baz',
-          },
-        },
-        {
-          '@id': '/v12/carts/1',
-          status: 'payed',
-          data: {
-            foo: 'bar',
-            bad: 'baz',
-          },
-        },
-        cartMetadata
-      )
-    ).toEqual({});
   });
 
   test('get dirty data with more data', () => {
@@ -540,5 +497,134 @@ describe('UnitOfWork', () => {
         customerPaidAmount: 1500,
       },
     });
+  });
+
+  test('get dirty data with object data', () => {
+    expect(
+      unitOfWork.getDirtyData(
+        {
+          '@id': '/v12/carts/1',
+          status: 'payed',
+          data: {
+            foo: 'bar',
+            loo: 'baz',
+          },
+        },
+        {
+          '@id': '/v12/carts/1',
+          status: 'payed',
+          data: {
+            foo: 'bar',
+          },
+        },
+        cartMetadata
+      )
+    ).toEqual({ data: { foo: 'bar', loo: 'baz' } });
+
+    expect(
+      unitOfWork.getDirtyData(
+        {
+          '@id': '/v12/carts/1',
+          status: 'payed',
+          data: {
+            foo: 'bar',
+            bad: 'baz',
+          },
+        },
+        {
+          '@id': '/v12/carts/1',
+          status: 'payed',
+          data: {
+            foo: 'bar',
+            bad: 'baz',
+          },
+        },
+        cartMetadata
+      )
+    ).toEqual({});
+  });
+
+  test('get dirty data with array data', () => {
+    expect(
+      unitOfWork.getDirtyData(
+        {
+          '@id': '/v12/carts/1',
+          status: 'payed',
+          codeList: ['bar', 'baz'],
+        },
+        {
+          '@id': '/v12/carts/1',
+          status: 'payed',
+          codeList: ['bar'],
+        },
+        cartMetadata
+      )
+    ).toEqual({ codeList: ['bar', 'baz'] });
+
+    expect(
+      unitOfWork.getDirtyData(
+        {
+          '@id': '/v12/carts/1',
+          status: 'payed',
+          codeList: ['bar', 'baz'],
+        },
+        {
+          '@id': '/v12/carts/1',
+          status: 'payed',
+          codeList: ['bar', 'baz'],
+        },
+        cartMetadata
+      )
+    ).toEqual({});
+  });
+
+  test('get dirty data with complex array data', () => {
+    expect(
+      unitOfWork.getDirtyData(
+        {
+          '@id': '/v12/carts/1',
+          status: 'payed',
+          codeList: [{ bar: 'bar' }, { baz: 'baz' }],
+        },
+        {
+          '@id': '/v12/carts/1',
+          status: 'payed',
+          codeList: [{ bar: 'bar' }],
+        },
+        cartMetadata
+      )
+    ).toEqual({ codeList: [{ bar: 'bar' }, { baz: 'baz' }] });
+
+    expect(
+      unitOfWork.getDirtyData(
+        {
+          '@id': '/v12/carts/1',
+          status: 'payed',
+          codeList: [{ bar: 'bar' }, { baz: 'baz' }],
+        },
+        {
+          '@id': '/v12/carts/1',
+          status: 'payed',
+          codeList: [{ bar: 'bar' }, { baz: 'bad' }],
+        },
+        cartMetadata
+      )
+    ).toEqual({ codeList: [{ bar: 'bar' }, { baz: 'baz' }] });
+
+    expect(
+      unitOfWork.getDirtyData(
+        {
+          '@id': '/v12/carts/1',
+          status: 'payed',
+          codeList: [{ bar: 'bar' }, { baz: 'baz' }],
+        },
+        {
+          '@id': '/v12/carts/1',
+          status: 'payed',
+          codeList: [{ bar: 'bar' }, { baz: 'baz' }],
+        },
+        cartMetadata
+      )
+    ).toEqual({});
   });
 });

--- a/src/UnitOfWork.ts
+++ b/src/UnitOfWork.ts
@@ -148,7 +148,7 @@ class UnitOfWork {
   ): StringKeyObject {
     const dirtyFields = dirtyFieldsParam;
 
-    if (attribute.type === 'object') {
+    if (attribute.type === 'object' || attribute.type === 'array') {
       if (oldValue === undefined || objectDiffers(oldValue, newValue)) {
         dirtyFields[key] = newValue;
       }


### PR DESCRIPTION
### Actual

If an attribute is declared as "array", it will fall into the dirty fields every time.

### New 

We use the same "diff" as the object one. 
