### PR TITLE
Add patch method using the PATCH HTTP verb

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,12 +207,17 @@ sdk.getRepository('products').create(entity);
 
 sdk.getRepository('products').update(entity);
 
+sdk.getRepository('products').patch(entity);
+
 sdk.getRepository('products').delete(entity);
 ```
 
 All these methods returns promises.
-`create` and `update` returns a `Promise<Entity>` with the new entity.
+`create`, `update` and `patch` returns a `Promise<Entity>` with the new entity.
 `delete` returns `Promise<void>`.
+
+`update` and `patch` behave the same way (same arguments, same UnitOfWork
+dirty-field handling) but use the `PUT` and `PATCH` HTTP verbs respectively.
 
 ### Overriding repository
 

--- a/__tests__/client/AbstractClient.test.js
+++ b/__tests__/client/AbstractClient.test.js
@@ -596,6 +596,21 @@ describe('Fix bugs', () => {
       });
   });
 
+  test('allow passing request params in patch', () => {
+    const test = {
+      '@id': '/v2/tests/1',
+    };
+
+    fetchMock.mock(() => true, {});
+
+    return SomeSdk.getRepository('test')
+      .patch(test, {}, { headers: { foo: 'bar' } })
+      .then(() => {
+        expect(fetchMock.lastOptions().headers.foo).toEqual('bar');
+        expect(fetchMock.lastOptions().method).toEqual('PATCH');
+      });
+  });
+
   test('allow passing request params in delete', () => {
     fetchMock.mock(() => true, {});
     const test = {
@@ -1104,6 +1119,55 @@ describe('Test unit of work', () => {
 
     await repo.update(cart);
     expect(findLastOptions('put_cart').body).toEqual('{}');
+  });
+
+  test('patching data with unit of work', async () => {
+    fetchMock
+      .mock({
+        name: 'get_cart',
+        matcher: 'end:/v12/carts/1',
+        method: 'GET',
+        response: JSON.stringify({
+          '@id': '/v12/carts/1',
+          status: null,
+          cartItemList: [
+            {
+              '@id': null,
+              quantity: 1,
+              cart: null,
+            },
+          ],
+        }),
+      })
+      .mock({
+        name: 'patch_cart',
+        matcher: 'end:/v12/carts/1',
+        method: 'PATCH',
+        response: JSON.stringify({
+          '@id': '/v12/carts/1',
+          status: 'foo',
+          cartItemList: [
+            {
+              '@id': null,
+              quantity: 1,
+              cart: null,
+            },
+          ],
+        }),
+      });
+
+    const repo = unitOfWorkSdk.getRepository('carts');
+    const cart = await repo.find('/v12/carts/1');
+    cart.status = 'foo';
+
+    await repo.patch(cart);
+    expect(findLastOptions('patch_cart').method).toEqual('PATCH');
+    expect(findLastOptions('patch_cart').body).toEqual(
+      JSON.stringify({ status: 'foo' })
+    );
+
+    await repo.patch(cart);
+    expect(findLastOptions('patch_cart').body).toEqual('{}');
   });
 
   test('updating partial data with unit of work', async () => {

--- a/src/client/AbstractClient.ts
+++ b/src/client/AbstractClient.ts
@@ -180,6 +180,30 @@ class AbstractClient<D extends MetadataDefinition> {
     queryParam: Record<string, unknown> = {},
     requestParams: Record<string, unknown> = {}
   ): Promise<D['entity']> {
+    return this._update('PUT', entity, queryParam, requestParams);
+  }
+
+  /**
+   * partially update an entity using the `PATCH` HTTP verb
+   *
+   * @param {Record<string, unknown>} entity the entity to update
+   * @param {Record<string, unknown>} queryParam query parameters that will be added to the request
+   * @param {Record<string, unknown>} requestParams parameters that will be send as second parameter to the `fetch` call
+   */
+  patch(
+    entity: D['entity'],
+    queryParam: Record<string, unknown> = {},
+    requestParams: Record<string, unknown> = {}
+  ): Promise<D['entity']> {
+    return this._update('PATCH', entity, queryParam, requestParams);
+  }
+
+  private _update(
+    method: 'PUT' | 'PATCH',
+    entity: D['entity'],
+    queryParam: Record<string, unknown> = {},
+    requestParams: Record<string, unknown> = {}
+  ): Promise<D['entity']> {
     const url = new URI(this.getEntityURI(entity));
     url.addSearch(queryParam);
 
@@ -204,7 +228,7 @@ class AbstractClient<D extends MetadataDefinition> {
 
     return this.deserializeResponse(
       this.authorizedFetch(url, {
-        method: 'PUT',
+        method,
         body: this.serializer.encodeItem(newSerializedModel, this.metadata),
         ...requestParams,
       }),


### PR DESCRIPTION
## Summary

Adds a `patch` method to `AbstractClient`, available on every repository.

It behaves exactly like `update` (same arguments, same UnitOfWork dirty-field handling — only dirty fields are sent) but issues a `PATCH` request instead of `PUT`.

```js
sdk.getRepository('products').patch(entity);
```

## Implementation

- Factored the shared body of `update` into a private `_update(method, …)` helper.
- `update()` delegates to `_update('PUT', …)`, `patch()` delegates to `_update('PATCH', …)`.

## Tests

- `allow passing request params in patch` — checks request params forwarding and that the `PATCH` verb is used.
- `patching data with unit of work` — checks the dirty-diff works with PATCH (only `{ status: 'foo' }` is sent, then `{}` when nothing changed).

All `AbstractClient` tests and `yarn lint` pass.

## Note

The content type stays `application/json` (same as `update`). If your API expects `application/merge-patch+json`, pass it via `requestParams.headers`.